### PR TITLE
Improve naming of denormalize method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Change name of parameter for denormalize method to `$data`.
+
 ## 0.1.0
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install package through composer:
 composer require digital-craftsman/deserializing-connection
 ```
 
-> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/deserializing-connection:0.1.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
+> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/deserializing-connection:0.2.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
 
 ## Usage
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,25 @@
 # Upgrade guide
 
-No upgrade available yet.
+## From 0.1.* to 0.2.0
+
+### Rename parameter
+
+Change name of parameter for `denormalize` method to `$data`.
+
+Before:
+
+```php
+public static function denormalize(array $array): self
+{
+    return new self($array);
+}
+```
+
+After:
+
+```php
+public static function denormalize(array $data): self
+{
+    return new self($data);
+}
+```

--- a/src/Serializer/ArrayNormalizable.php
+++ b/src/Serializer/ArrayNormalizable.php
@@ -6,7 +6,7 @@ namespace DigitalCraftsman\DeserializingConnection\Serializer;
 
 interface ArrayNormalizable
 {
-    public static function denormalize(array $array): self;
+    public static function denormalize(array $data): self;
 
     public function normalize(): array;
 }

--- a/src/Serializer/FloatNormalizable.php
+++ b/src/Serializer/FloatNormalizable.php
@@ -6,7 +6,7 @@ namespace DigitalCraftsman\DeserializingConnection\Serializer;
 
 interface FloatNormalizable
 {
-    public static function denormalize(float $float): self;
+    public static function denormalize(float $data): self;
 
     public function normalize(): float;
 }

--- a/src/Serializer/IntNormalizable.php
+++ b/src/Serializer/IntNormalizable.php
@@ -6,7 +6,7 @@ namespace DigitalCraftsman\DeserializingConnection\Serializer;
 
 interface IntNormalizable
 {
-    public static function denormalize(int $int): self;
+    public static function denormalize(int $data): self;
 
     public function normalize(): int;
 }

--- a/src/Serializer/StringNormalizable.php
+++ b/src/Serializer/StringNormalizable.php
@@ -6,7 +6,7 @@ namespace DigitalCraftsman\DeserializingConnection\Serializer;
 
 interface StringNormalizable
 {
-    public static function denormalize(string $string): self;
+    public static function denormalize(string $data): self;
 
     public function normalize(): string;
 }

--- a/tests/Test/DTO/Project.php
+++ b/tests/Test/DTO/Project.php
@@ -21,13 +21,13 @@ final readonly class Project implements ArrayNormalizable
      * @param array{
      *     projectId: string,
      *      name: string,
-     * } $array
+     * } $data
      */
-    public static function denormalize(array $array): self
+    public static function denormalize(array $data): self
     {
         return new self(
-            projectId: ProjectId::fromString($array['projectId']),
-            name: $array['name'],
+            projectId: ProjectId::fromString($data['projectId']),
+            name: $data['name'],
         );
     }
 

--- a/tests/Test/ValueObject/Limit.php
+++ b/tests/Test/ValueObject/Limit.php
@@ -22,9 +22,9 @@ final readonly class Limit implements IntNormalizable
     // -- Int normalizable
 
     #[\Override]
-    public static function denormalize(int $int): self
+    public static function denormalize(int $data): self
     {
-        return new self($int);
+        return new self($data);
     }
 
     #[\Override]

--- a/tests/Test/ValueObject/Range.php
+++ b/tests/Test/ValueObject/Range.php
@@ -22,9 +22,9 @@ final readonly class Range implements FloatNormalizable
     // -- Float normalizable
 
     #[\Override]
-    public static function denormalize(float $float): self
+    public static function denormalize(float $data): self
     {
-        return new self($float);
+        return new self($data);
     }
 
     #[\Override]

--- a/tests/Test/ValueObject/SearchTerm.php
+++ b/tests/Test/ValueObject/SearchTerm.php
@@ -22,9 +22,9 @@ final readonly class SearchTerm implements StringNormalizable
     // -- String normalizable
 
     #[\Override]
-    public static function denormalize(string $string): self
+    public static function denormalize(string $data): self
     {
-        return new self($string);
+        return new self($data);
     }
 
     #[\Override]


### PR DESCRIPTION
## Changes

- Renamed parameter of `denormalize` methods in all interfaces to `$data`.